### PR TITLE
Refactor: Update dependencies and build scripts for Java 11/JUnit 5 c…

### DIFF
--- a/SystaRESTServer/build.sh
+++ b/SystaRESTServer/build.sh
@@ -22,4 +22,16 @@ cp ./src/SystaREST.properties ./bin/
 cp ./src/rawdatamonitor.html ./bin/
 cp ./src/fakeremoteportal.html ./bin/
 cp ./src/systapidashboard.html ./bin/
-javac -encoding utf8 -d ./bin/ -classpath ./bin:./lib/aopalliance-repackaged-3.0.1.jar:./lib/hk2-api-3.0.1.jar:./lib/hk2-locator-3.0.1.jar:./lib/hk2-utils-3.0.1.jar:./lib/jakarta.inject-api-2.0.0.jar:./lib/jakarta.json.bind-api-2.0.0.jar:./lib/jakarta.json-2.0.0-module.jar:./lib/jakarta.json-api-2.0.0.jar:./lib/jakarta.persistence-api-3.0.0.jar:./lib/jakarta.servlet-api-5.0.0.jar:./lib/jakarta.validation-api-3.0.0.jar:./lib/jakarta.ws.rs-api-3.0.0.jar:./lib/jakarta.ws.rs-api-3.0.0-sources.jar:./lib/javassist-3.25.0-GA.jar:./lib/jersey-client-3.0.2.jar:./lib/jersey-common-3.0.2.jar:./lib/jersey-container-jdk-http-3.0.2.jar:./lib/jersey-container-servlet-3.0.2.jar:./lib/jersey-container-servlet-core-3.0.2.jar:./lib/jersey-hk2-3.0.2.jar:./lib/jersey-media-jaxb-3.0.2.jar:./lib/jersey-media-json-binding-3.0.2.jar:./lib/jersey-media-sse-3.0.2.jar:./lib/jersey-server-3.0.2.jar:./lib/org.osgi.core-6.0.0.jar:./lib/osgi-resource-locator-1.0.3.jar:./lib/yasson-2.0.1.jar:./lib/jersey-test-framework-core-3.0.2.jar:./lib/jersey-test-framework-provider-grizzly2-3.0.2.jar ./src/de/freaklamarsch/systarest/*.java
+
+# Construct classpath
+CP="./bin"
+for jarfile in ./lib/*.jar; do
+  # Exclude test-specific JARs for the main build script
+  if [[ "$jarfile" != *"jersey-test-framework-core"* && \
+        "$jarfile" != *"jersey-test-framework-provider-grizzly2"* && \
+        "$jarfile" != *"hamcrest-core"* ]]; then
+    CP="$CP:$jarfile"
+  fi
+done
+
+javac -encoding utf8 -d ./bin/ -classpath "$CP" ./src/de/freaklamarsch/systarest/*.java

--- a/SystaRESTServer/build_test.sh
+++ b/SystaRESTServer/build_test.sh
@@ -18,10 +18,18 @@
 #
 
 rm -rf ./bin/*
-javac -encoding utf8 -d ./bin/ -classpath ./bin:./lib/aopalliance-repackaged-3.0.1.jar:./lib/hk2-api-3.0.1.jar:./lib/hk2-locator-3.0.1.jar:./lib/hk2-utils-3.0.1.jar:./lib/jakarta.inject-api-2.0.0.jar:./lib/jakarta.json.bind-api-2.0.0.jar:./lib/jakarta.json-2.0.0-module.jar:./lib/jakarta.json-api-2.0.0.jar:./lib/jakarta.persistence-api-3.0.0.jar:./lib/jakarta.servlet-api-5.0.0.jar:./lib/jakarta.validation-api-3.0.0.jar:./lib/jakarta.ws.rs-api-3.0.0.jar:./lib/jakarta.ws.rs-api-3.0.0-sources.jar:./lib/javassist-3.25.0-GA.jar:./lib/jersey-client-3.0.2.jar:./lib/jersey-common-3.0.2.jar:./lib/jersey-container-jdk-http-3.0.2.jar:./lib/jersey-container-servlet-3.0.2.jar:./lib/jersey-container-servlet-core-3.0.2.jar:./lib/jersey-hk2-3.0.2.jar:./lib/jersey-media-jaxb-3.0.2.jar:./lib/jersey-media-json-binding-3.0.2.jar:./lib/jersey-media-sse-3.0.2.jar:./lib/jersey-server-3.0.2.jar:./lib/org.osgi.core-6.0.0.jar:./lib/osgi-resource-locator-1.0.3.jar:./lib/yasson-2.0.1.jar:./lib/jersey-test-framework-core-3.0.2.jar:./lib/jersey-test-framework-provider-grizzly2-3.0.2.jar:../.github/workflows/junit-platform-console-standalone-1.8.1.jar ./src/de/freaklamarsch/systarest/*.java ./src/de/freaklamarsch/systarest/tests/*.java
+
+# Construct classpath
+CP_TEST="./bin"
+for jarfile in ./lib/*.jar; do
+  CP_TEST="$CP_TEST:$jarfile"
+done
+CP_TEST="$CP_TEST:../.github/workflows/junit-platform-console-standalone-1.8.1.jar"
+
+javac -encoding utf8 -d ./bin/ -classpath "$CP_TEST" ./src/de/freaklamarsch/systarest/*.java ./src/de/freaklamarsch/systarest/tests/*.java
 cp ./src/SystaREST.properties ./bin/
 cp ./src/rawdatamonitor.html ./bin/
 cp ./src/fakeremoteportal.html ./bin/
 cp ./src/systapidashboard.html ./bin/
 cp ./src/de/freaklamarsch/systarest/tests/*.txt ./bin/de/freaklamarsch/systarest/tests/ 
-cp ./src/de/freaklamarsch/systarest/tests/*.h ./bin/de/freaklamarsch/systarest/tests/ 
+cp ./src/de/freaklamarsch/systarest/tests/*.h ./bin/de/freaklamarsch/systarest/tests/


### PR DESCRIPTION
…ompatibility.

This commit updates the JAR dependencies in `SystaRESTServer/lib` to versions compatible with Java 11 and JUnit 5.

Key changes include:
- Updated Jakarta EE APIs, Grizzly, HK2, Jersey, Hamcrest, Javassist, JAXB, Yasson, and OSGi core libraries to their more recent and compatible versions.
- Modified `SystaRESTServer/build.sh` and `SystaRESTServer/build_test.sh` to dynamically generate the classpath by including all JARs from the `lib` directory. This simplifies classpath management.
- Test-specific JARs are now correctly excluded from the main build script's classpath.
- Removed unused `jakarta.ws.rs-api-3.0.0-sources.jar` and consolidated `jakarta.json-*.jar` files into `jakarta.json-api-2.1.3.jar`.

The project successfully compiles and tests pass with these changes.