### PR TITLE
I've fixed the JUnit test classpath in your GitHub workflow.

### DIFF
--- a/.github/workflows/junit.yml
+++ b/.github/workflows/junit.yml
@@ -40,8 +40,12 @@ jobs:
       # Runs a single command using the runners shell
       - name: run JUnit tests
         run: |
+          CP_TEST="./SystaRESTServer/bin"
+          for jarfile in ./SystaRESTServer/lib/*.jar; do
+            CP_TEST="$CP_TEST:$jarfile"
+          done
           ls -al ./SystaRESTServer/bin/
-          java -jar .github/workflows/junit-platform-console-standalone-1.13.4.jar -cp ./SystaRESTServer/bin/ --scan-classpath -reports-dir='junit-reports/'
+          java -jar .github/workflows/junit-platform-console-standalone-1.13.4.jar -cp "$CP_TEST" --scan-classpath -reports-dir='junit-reports/'
 
       # Publish the test results
       - name: Publish Test Report


### PR DESCRIPTION
I noticed your JUnit tests were failing in the GitHub Actions workflow with a `NoClassDefFoundError: jakarta/json/JsonValue`.

This was caused by an incomplete classpath during the test execution step. The command for running the JUnit console only included the compiled classes' directory (`./SystaRESTServer/bin`) but not the required dependency JARs from `./SystaRESTServer/lib`.

To fix this, I updated the `junit.yml` workflow file. It now includes a shell script snippet that constructs the full classpath, including all library JARs, before executing the tests. This ensures that all dependencies are available on the classpath at runtime, resolving the error.